### PR TITLE
Ekinzie/uninit data fixes

### DIFF
--- a/src/restconf-method.c
+++ b/src/restconf-method.c
@@ -528,6 +528,8 @@ int data_post(struct CgiContext *cgi, char **pathvec, int root) {
     retval = restconf_operation_failed_internal();
     goto done;
   }
+
+  key_out[0] = 0;
   root_key_copy = str_dup(root_key);
   struct json_object *created = NULL;
   if ((created = json_get_object_from_map(top_level, root_key_copy))) {
@@ -700,6 +702,7 @@ int data_put(struct CgiContext *cgi, char **pathvec, int root) {
 
   delete_uci = uci;
 
+  key_out[0] = 0;
   if (yang_is_list(json_get_string(top_level, YANG_TYPE))) {
     struct json_object *keys = NULL;
     if ((keys = json_get_array(top_level, YANG_KEYS))) {

--- a/src/restconf.c
+++ b/src/restconf.c
@@ -38,7 +38,7 @@ static int api_root(struct CgiContext *cgi) {
 static int data_root(struct CgiContext *cgi, char **pathvec) {
   int retval = 1;
 
-  if (pathvec[1] == NULL) {
+  if (vector_size(pathvec) == 1) {
     // root
     if (is_OPTIONS(cgi->method)) {
       content_type_json();


### PR DESCRIPTION
Hi, here are a couple of trivial changes I made to get the tavern-ci tests to pass on my systems.  Both deal with uninitialized memory.  I tested with openwrt 18.06 on arm64.